### PR TITLE
Fix HTTP 500 error when invalid date is entered in workload filter

### DIFF
--- a/app/controllers/workloads_controller.rb
+++ b/app/controllers/workloads_controller.rb
@@ -110,10 +110,10 @@ class WorkloadsController < ApplicationController
   end
 
   def sanitizeDateParameter(parameter, default)
-    if parameter.respond_to?(:to_date)
-      parameter.to_date
-    else
-      default
-    end
+    return default unless parameter.respond_to?(:to_date)
+
+    parameter.to_date
+  rescue Date::Error
+    default
   end
 end

--- a/test/functional/workloads_controller_test.rb
+++ b/test/functional/workloads_controller_test.rb
@@ -43,5 +43,32 @@ module RedmineWorkload
 
       assert flash[:error].match(/Character encoding not allowed./)
     end
+
+    test 'should get index with invalid first_day date without raising an error' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: { first_day: '2026-01-32' })
+      assert_response :success
+    end
+
+    test 'should get index with invalid last_day date without raising an error' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: { last_day: '2026-13-01' })
+      assert_response :success
+    end
+
+    test 'should get index with invalid start_date without raising an error' do
+      manager = roles :roles_001
+      manager.add_permission! :view_all_workloads
+      log_user('jsmith', 'jsmith')
+
+      get workloads_path(workload: { start_date: 'not-a-date' })
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
Wrap the `to_date` conversion in `sanitizeDateParameter` with a begin-rescue block to catch `Date::Error`. Previously, strings like "2026-01-32" passed the `respond_to?(:to_date)` check but raised an unhandled exception during conversion. Now invalid dates fall back to the default value instead of crashing.

Adds functional tests for all three date parameters (first_day, last_day, start_date) to cover the invalid date case.

Fixes https://github.com/xmera-circle/redmine_workload/issues/41
